### PR TITLE
Compatibility Repetier-dev branch

### DIFF
--- a/delta_cal/static/js/deltaautocal.js
+++ b/delta_cal/static/js/deltaautocal.js
@@ -815,7 +815,7 @@ $(function () {
 			break;
 		   }
                 self.probeCount++;
-                if (self.probeCount == numPoints)  {
+                if (self.probeCount === numPoints)  {
                   startDeltaCalcEngine();  // doooo eeeeeeet!
                 }
               }

--- a/delta_cal/static/js/deltaautocal.js
+++ b/delta_cal/static/js/deltaautocal.js
@@ -11,7 +11,7 @@ $(function () {
         const SMC_ERIS = 3;
         const SMC_MAX_V3 = 5;
         const SMC_H2 = 6;
-        const DEFAULT_PROBE_HEIGHT = 25;
+        const DEFAULT_PROBE_HEIGHT = 5;
 
         self.machineType = 0;
 
@@ -799,16 +799,13 @@ $(function () {
                   self.sentM114 = false;
                 }
               }
-              if (self.probingActive && line.includes("PROBE-ZOFFSET")) {
+          	if (self.probingActive && (line.includes("PROBE-ZOFFSET") || line.includes("Z-probe"))) {
                 var zCoord = line.split(":");
                 self.statusMessage(self.statusMessage() + ".");
-                console.log(" Probe #" + parseInt(self.probeCount + 1) + " value: " + parseFloat(zCoord[2]) +
-                " X: " + parseFloat(xBedProbePoints[self.probeCount]) +
-                " Y: " + parseFloat(yBedProbePoints[self.probeCount]));
-                
-                zBedProbePoints[self.probeCount] = -parseFloat(zCoord[2]);
+		console.log(" Probe #" + parseInt(self.probeCount + 1) + " value: " + ((-1*DEFAULT_PROBE_HEIGHT)+parseFloat(zCoord[2])) + " X: " + parseFloat(xBedProbePoints[self.probeCount]) + " Y: " + parseFloat(yBedProbePoints[self.probeCount]));
+                zBedProbePoints[self.probeCount] = -parseFloat(zCoord[2]) + DEFAULT_PROBE_HEIGHT;
                 self.probeCount++;
-                if (self.probeCount == numPoints)  { 
+                if (self.probeCount == numPoints)  {
                   startDeltaCalcEngine();  // doooo eeeeeeet!
                 }
               }

--- a/delta_cal/static/js/deltaautocal.js
+++ b/delta_cal/static/js/deltaautocal.js
@@ -800,10 +800,20 @@ $(function () {
                 }
               }
           	if (self.probingActive && (line.includes("PROBE-ZOFFSET") || line.includes("Z-probe"))) {
-                var zCoord = line.split(":");
-                self.statusMessage(self.statusMessage() + ".");
-		console.log(" Probe #" + parseInt(self.probeCount + 1) + " value: " + ((-1*DEFAULT_PROBE_HEIGHT)+parseFloat(zCoord[2])) + " X: " + parseFloat(xBedProbePoints[self.probeCount]) + " Y: " + parseFloat(yBedProbePoints[self.probeCount]));
-                zBedProbePoints[self.probeCount] = -parseFloat(zCoord[2]) + DEFAULT_PROBE_HEIGHT;
+		   switch(line.includes()) {
+			case "Z-probe" :
+                	   var zCoord = line.split(":");
+                	   self.statusMessage(self.statusMessage() + ".");
+			   console.log(" Probe #" + parseInt(self.probeCount + 1) + " value: " + ((-1*DEFAULT_PROBE_HEIGHT)+parseFloat(zCoord[2])) + " X: " + parseFloat(xBedProbePoints[self.probeCount]) + " Y: " + parseFloat(yBedProbePoints[self.probeCount]));
+                	   zBedProbePoints[self.probeCount] = -parseFloat(zCoord[2]) + DEFAULT_PROBE_HEIGHT;
+			break;
+			case "PROBE-ZOFFSET" : 
+		           var zCoord = line.split(":");
+                           self.statusMessage(self.statusMessage() + ".");
+                           console.log(" Probe #" + parseInt(self.probeCount + 1) + " value: " + parseFloat(zCoord[2]) + " X: " + parseFloat(xBedProbePoints[self.probeCount]) + " Y: " + parseFloat(yBedProbePoints[self.probeCount]));
+                           zBedProbePoints[self.probeCount] = -parseFloat(zCoord[2]);
+			break;
+		   }
                 self.probeCount++;
                 if (self.probeCount == numPoints)  {
                   startDeltaCalcEngine();  // doooo eeeeeeet!


### PR DESCRIPTION
I noticed Repetier's return for Z-probes had changed between .92 and 1.0.x

1.0.4 returns the probed value + whatever the starting height is.
I left the original routine as part of a switch statement I added.
Commit with switch() is currently untested.