### PR TITLE
Add __plugin_pythoncompat__ so plugin will work with the latest octop…

### DIFF
--- a/delta_cal/__init__.py
+++ b/delta_cal/__init__.py
@@ -38,6 +38,8 @@ class DeltaCalPlugin(octoprint.plugin.AssetPlugin,
 
 __plugin_name__ = "Delta Autocalibration"
 
+__plugin_pythoncompat__ = ">=3,<4"
+
 def __plugin_load__():
     global __plugin_implementation__
     __plugin_implementation__ = DeltaCalPlugin()


### PR DESCRIPTION
I tried to install this on my octoprint setup and was getting an error saying it was incompatible.

The fix seems to have been to just add __plugin_pythoncompat__ = ">=3,<4" to the __init__.py,

Running great and was able to calibrate successfully.